### PR TITLE
Update 2022-06-05-setup-ijava-jupyter-kernel.md

### DIFF
--- a/_posts/2022-06-05-setup-ijava-jupyter-kernel.md
+++ b/_posts/2022-06-05-setup-ijava-jupyter-kernel.md
@@ -35,7 +35,7 @@ git checkout try-upgrade-gradle
 cd ..
 git clone https://github.com/hanslovsky/IJava.git
 cd IJava/
-git checkout hanslovsky/gradle-7.4.2
+git checkout gradle-7.4.2
 ./gradlew installKernel
 ```
 


### PR DESCRIPTION
This PR fixes a typo in the setup instructions.
The current instructions, if followed verbatim, give the error below.

```
➜  IJava git:(master) git checkout hanslovsky/gradle-7.4.2
error: pathspec 'hanslovsky/gradle-7.4.2' did not match any file(s) known to git
➜  IJava git:(master) 
➜  IJava git:(master) git checkout gradle-7.4.2 
Branch 'gradle-7.4.2' set up to track remote branch 'gradle-7.4.2' from 'origin'.
```